### PR TITLE
use on('close') instead of on('complete')

### DIFF
--- a/tasks/lib/fontello.js
+++ b/tasks/lib/fontello.js
@@ -135,7 +135,7 @@ var fetchStream = function(options, session, callback){
           }
         }
       })
-      .on('finish', function(){
+      .on('close', function(){
         grunt.log.ok();
         callback(null, 'extract complete');
       });


### PR DESCRIPTION
when using on('complete') my grunt task finishes before it has processed all teh files, as a result it's most of the time not dumping the css files.
