### PR TITLE
Follow keep alive requests on fetch

### DIFF
--- a/tasks/lib/fontello.js
+++ b/tasks/lib/fontello.js
@@ -123,12 +123,19 @@ var fetchStream = function(options, session, callback){
   if (/Invalid/.test(session))
     throw new Error(session);
 
+  var getOptions = {
+    follow: 10
+  };
   var tempConfig = process.cwd() + '/config-tmp.json';
   var tempZip = process.cwd() + '/fontello-tmp.zip';
   setSession(options, session);
 
   grunt.log.write('Fetching archive...');
-  needle.get(options.host + '/' + session + '/get', function(err, response, body){
+  needle.get(options.host + '/' + session + '/get', getOptions, function(err, response, body){
+
+    if (err) {
+      throw err;
+    }
 
     if(response.statusCode == 404)
     {


### PR DESCRIPTION
This is a parallel PR to what I submitted in https://github.com/paulyoung/fontello-cli/pull/29.  The purpose is to fix frequent error messages occurring recently that look like this:
```
Fetching archive...Fatal error: Cannot read property 'statusCode' of undefined
```