### PR TITLE
Fix for 500 status code if session expires and session id is no more valid

### DIFF
--- a/tasks/fontello.js
+++ b/tasks/fontello.js
@@ -29,8 +29,9 @@ module.exports = function(grunt) {
         updateConfig   : false
       });
 
-    var recipe = [ 
+    var recipe = [
       fontello.init.bind(null, options),
+      fontello.check,
       fontello.post,
       fontello.fetch
     ];


### PR DESCRIPTION
Added one step to waterfall flow to check if session is expired or not. It's clumsy solution but helps to remove `Fatal error: invalid signature: 0x3030355b` error
