### PR TITLE
Store session in seperate file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ npm-debug.log
 tmp
 .idea
 test/output
+session

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -25,7 +25,8 @@ module.exports = function(grunt) {
 
     // Before generating any new files, remove any previously-created files.
     clean: {
-      tests: ['tmp']
+      tests: ['tmp'],
+      tmp: ['session']
     },
 
     // Configuration to be run (and then tested).

--- a/tasks/fontello.js
+++ b/tasks/fontello.js
@@ -25,11 +25,10 @@ module.exports = function(grunt) {
         exclude        : [],
         zip            : false,
         scss           : false,
-        force          : true,
-        updateConfig   : false
+        force          : true
       });
 
-    var recipe = [ 
+    var recipe = [
       fontello.init.bind(null, options),
       fontello.post,
       fontello.fetch

--- a/tasks/lib/fontello.js
+++ b/tasks/lib/fontello.js
@@ -134,7 +134,6 @@ var fetchStream = function(options, session, callback){
   var getOptions = {
     follow: 10
   };
-  var tempConfig = process.cwd() + '/config-tmp.json';
   var tempZip = process.cwd() + '/fontello-tmp.zip';
 
   grunt.log.write('Fetching archive...');
@@ -181,15 +180,6 @@ var fetchStream = function(options, session, callback){
                   path.join(options.styles, '_' + path.basename(entry.path).replace(ext, '.scss'));
                   return entry.pipe(fs.createWriteStream(cssPath));
                 }
-              case '.json':
-                if (options.updateConfig) {
-                  var r = entry.pipe(fs.createWriteStream(tempConfig));
-                  r.on('finish', function() {
-                    var config = require(tempConfig);
-                    setSession(options, session, config);
-                    fs.unlinkSync(tempConfig);
-                  });
-               }
               // Drain everything else
               default:
                 grunt.verbose.writeln('Ignored ', entry.path);

--- a/tasks/lib/fontello.js
+++ b/tasks/lib/fontello.js
@@ -32,8 +32,7 @@ var processPath = function(options, dir, callback){
 var getSession = function(){
   var src = path.resolve(process.cwd(), 'node_modules/grunt-fontello/session');
 
-  // Make sure the session file exists, return `null`
-  // if it doesn't
+  // Make sure the session file exists, return `null` otherwise.
   if (!fs.existsSync(src)) {
     return null;
   }
@@ -43,7 +42,14 @@ var getSession = function(){
 }
 
 var setSession = function(session){
-  var dest = path.resolve(process.cwd(), 'node_modules/grunt-fontello/session');
+  var dir = path.resolve(process.cwd(), 'node_modules/grunt-fontello');
+  var dest = path.resolve(dir, 'session');
+
+  // Make sure the grunt-fontello directory exists, otherwise
+  // just don't safe the session.
+  if (!fs.existsSync(dir)) {
+    return null;
+  }
 
   // Write session to the session file since the Fontello
   // api dislikes custom members.

--- a/tasks/lib/fontello.js
+++ b/tasks/lib/fontello.js
@@ -30,15 +30,11 @@ var processPath = function(options, dir, callback){
 };
 
 var setSession = function(options, session, config){
-  var dest = process.cwd() + '/' + options.config;
-
-  if (undefined == config)
-    config = require(dest);
+  var dest = path.resolve(process.cwd(), 'node_modules/grunt-fontello/session');
 
   // Write session to config file. Save session in name field since the
   // Fontello api dislikes custom members.
-  config.name = session;
-  fs.writeFileSync(dest, JSON.stringify(config, null, '\t'));
+  fs.writeFileSync(dest, session);
 }
 
 /*
@@ -75,8 +71,6 @@ var init = function(options, callback){
 * @callback: session id
 * */
 var createSession = function(options, callback){
-
-  // TODO: save session somewhere else?
 
   var data = {
     config: {
@@ -154,7 +148,7 @@ var fetchStream = function(options, session, callback){
         .on('entry', function(entry){
           var ext = path.extname(entry.path);
           var name = path.basename(entry.path);
-          
+
           if(entry.type === 'File') {
             if(options.exclude.indexOf(name) !== -1) {
                 grunt.verbose.writeln('Ignored ', entry.path);

--- a/tasks/lib/fontello.js
+++ b/tasks/lib/fontello.js
@@ -29,11 +29,24 @@ var processPath = function(options, dir, callback){
   });
 };
 
-var setSession = function(options, session, config){
+var getSession = function(){
+  var src = path.resolve(process.cwd(), 'node_modules/grunt-fontello/session');
+
+  // Make sure the session file exists, return `null`
+  // if it doesn't
+  if (!fs.existsSync(src)) {
+    return null;
+  }
+
+  // Read session from the session file.
+  return fs.readFileSync(src, { encoding: 'utf-8'});
+}
+
+var setSession = function(session){
   var dest = path.resolve(process.cwd(), 'node_modules/grunt-fontello/session');
 
-  // Write session to config file. Save session in name field since the
-  // Fontello api dislikes custom members.
+  // Write session to the session file since the Fontello
+  // api dislikes custom members.
   fs.writeFileSync(dest, session);
 }
 
@@ -79,11 +92,9 @@ var createSession = function(options, callback){
     }
   };
 
-  var session = null;
-  var config = require(process.cwd() + '/' + options.config);
+  var session = getSession();
 
-  if (config.name) {
-    session = config.name
+  if (session !== null) {
     callback(null, options, session);
   }
   else {
@@ -96,6 +107,9 @@ var createSession = function(options, callback){
          else {
            grunt.log.ok();
            grunt.log.debug('sid: ' + body);
+
+           // Store the new sid and continue
+           setSession(body);
            callback(null, options, body);
          }
        }
@@ -122,7 +136,6 @@ var fetchStream = function(options, session, callback){
   };
   var tempConfig = process.cwd() + '/config-tmp.json';
   var tempZip = process.cwd() + '/fontello-tmp.zip';
-  setSession(options, session);
 
   grunt.log.write('Fetching archive...');
   needle.get(options.host + '/' + session + '/get', getOptions, function(err, response, body){


### PR DESCRIPTION
Now stores the session ID into a separate file in the `~/node_modules/grunt-fontello` folder.

- Renders PR #31 obsolete and solves issue #30
- Should work correctly when combined with PR #36