### PR TITLE
Add support for LESS

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,19 +56,20 @@ Folder to extract the full archive.
 Type: `String`
 Default value: `fonts`
 
-Path to extract font files (*.eot, *.woff, *.svg, *.ttf)
+Path to extract font files (`*.eot`, `*.woff`, `*.svg`, `*.ttf`)
 
 #### options.styles
 Type: `String`
 Default value: `css`
 
-Path to extract css or scss files. See [options.scss](#options_scss)
+Path to extract the stylesheets to.
 
-#### <a id="options_scss"></a>options.scss
-Type: `Boolean`
-Default value: `false`
+#### options.preprocessor
+Type: `String`
+Default value: `none`
 
-Setting this option to `true` will extract _.scss_ files instead of plain css.
+By default the outputted stylesheet will be _.css_. Changing this to `less` or `scss` will
+change the output to _.less_ or _.scss_ respectively.
 
 #### options.force
 Type: `Boolean`

--- a/tasks/fontello.js
+++ b/tasks/fontello.js
@@ -24,7 +24,7 @@ module.exports = function(grunt){
         styles         : 'css',
         exclude        : [],
         zip            : false,
-        scss           : false,
+        preprocessor   : 'none',
         force          : true
       });
 

--- a/tasks/fontello.js
+++ b/tasks/fontello.js
@@ -29,7 +29,8 @@ module.exports = function(grunt){
       });
 
     var recipe = [
-      fontello.init.bind(null, options),
+      fontello.deprecated.bind(null, options),
+      fontello.init,
       fontello.check,
       fontello.post,
       fontello.fetch,

--- a/tasks/lib/fontello.js
+++ b/tasks/lib/fontello.js
@@ -253,9 +253,22 @@ var fetchStream = function(options, session, callback){
                 case '.css':
                   // SCSS:
                   if (options.styles) {
-                    var cssPath = (!options.scss) ?
-                    path.join(options.styles, path.basename(entry.path)) :
-                    path.join(options.styles, '_' + path.basename(entry.path).replace(ext, '.scss'));
+                    var cssPath;
+                    switch(options.preprocessor.toLowerCase()) {
+                      case 'none':
+                        cssPath = path.join(options.styles, path.basename(entry.path));
+                        break;
+                      case 'less':
+                        cssPath = path.join(options.styles, path.basename(entry.path).replace(ext, '.less'));
+                        break;
+                      case 'scss':
+                        cssPath = path.join(options.styles, '_' + path.basename(entry.path).replace(ext, '.scss'));
+                        break;
+                      default:
+                        grunt.fail.warn('Unknown preprocessor "' + options.output + '"');
+                        return;
+                    }
+
                     return entry.pipe(fs.createWriteStream(cssPath));
                   }
                 // Drain everything else

--- a/tasks/lib/fontello.js
+++ b/tasks/lib/fontello.js
@@ -102,6 +102,17 @@ var setFontPath = function(options, callback){
 }
 
 /*
+* Broadcast deprecated messages.
+* @callback: options
+* */
+var deprecated = function(options, callback){
+  if(options.scss)
+    grunt.log.warn('You\'re using the deprecated option "scss", please switch to "preprocessor" as soon as possible');
+
+  callback(null, options);
+};
+
+/*
 * Initial Checks
 * @callback: options
 * */
@@ -256,7 +267,11 @@ var fetchStream = function(options, session, callback){
                     var cssPath;
                     switch(options.preprocessor.toLowerCase()) {
                       case 'none':
-                        cssPath = path.join(options.styles, path.basename(entry.path));
+                        if(options.scss === true) {
+                          cssPath = path.join(options.styles, '_' + path.basename(entry.path).replace(ext, '.scss'));
+                        } else {
+                          cssPath = path.join(options.styles, path.basename(entry.path));
+                        }
                         break;
                       case 'less':
                         cssPath = path.join(options.styles, path.basename(entry.path).replace(ext, '.less'));
@@ -300,9 +315,10 @@ var fetchStream = function(options, session, callback){
 };
 
 module.exports = {
-  init     : init,
-  check    : checkSession,
-  post     : createSession,
-  fetch    : fetchStream,
-  fontPath : setFontPath
+  deprecated : deprecated,
+  init       : init,
+  check      : checkSession,
+  post       : createSession,
+  fetch      : fetchStream,
+  fontPath   : setFontPath
 };


### PR DESCRIPTION
Resolves #17, maybe we should add support for LESS as output possibility besides SCSS.

To get this working I updated the existing `options` object, removed the `scss` option and added a new option called `preprocessor` which accepts 3 values: `"none"`, `"less"` and `"scss"` (case insensitive). I updated the README.md accordingly and also added backwards compatibility for the `scss` option, outputting a deprecated warning if it is being used.