### PR TITLE
cssFontPath

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,27 +42,27 @@ grunt.initConfig({
 
 #### options.config
 Type: `String`
-Default value: `config.json`
+Default value: `"config.json"`
 
-Path to your config.json file. Generate custom font icons [here](http://www.fontello.com);
+Path to your config.json file. Generate custom font icons [here](http://www.fontello.com).
 
 #### options.zip
 Type: `String`
-Default value: `.`
+Default value: `"."`
 
 Folder to extract the full archive.
 
 #### options.fonts
 Type: `String`
-Default value: `fonts`
+Default value: `"fonts"`
 
-Path to extract font files (*.eot, *.woff, *.svg, *.ttf)
+Path to extract font files (`*.eot`, `*.woff`, `*.svg`, `*.ttf`).
 
 #### options.styles
 Type: `String`
-Default value: `css`
+Default value: `"css"`
 
-Path to extract css or scss files. See [options.scss](#options_scss)
+Path to extract css or scss files. See [options.scss](#options_scss).
 
 #### <a id="options_scss"></a>options.scss
 Type: `Boolean`
@@ -80,7 +80,13 @@ By default, if the folder specified in _options.fonts_, _options.zip_ and _optio
 Type: `Array`
 Default value: `[]`
 
-An array of names of files which are excluded
+An array of names of files which are excluded.
+
+#### options.cssFontPath
+Type: `String`
+Default value: `undefined`
+
+An explicit path to where the fonts are relative to the _.css_/_.scss_ file.
 
 ### Example
 
@@ -120,7 +126,7 @@ grunt.initConfig({
       options: {
           fonts   : 'output/fonts',
           styles  : 'output/css',
-          exclude: ['animation.css', 'fontello-ie7-codes.css', 'fontello.eot'],
+          exclude : ['animation.css', 'fontello-ie7-codes.css', 'fontello.eot'],
       }
     },
   },

--- a/tasks/fontello.js
+++ b/tasks/fontello.js
@@ -25,7 +25,8 @@ module.exports = function(grunt){
         exclude        : [],
         zip            : false,
         scss           : false,
-        force          : true
+        force          : true,
+        cssFontPath    : undefined
       });
 
     var recipe = [

--- a/tasks/lib/fontello.js
+++ b/tasks/lib/fontello.js
@@ -69,7 +69,7 @@ var setSession = function(session){
 /* Set relative font path */
 var setFontPath = function(options, callback){
 
-  var css2FontPath = normalize(path.relative(options.styles, options.fonts));
+  var css2FontPath = options.cssFontPath || normalize(path.relative(options.styles, options.fonts));
   grunt.log.write('Processing font path...');
 
   try {
@@ -86,8 +86,8 @@ var setFontPath = function(options, callback){
 
         var content = fs.readFileSync(filePath);
         fs.writeFileSync(filePath, content.toString().replace(/\.\.\/font/g, css2FontPath));
-
       }
+
     });
 
     grunt.log.debug('Font path is ' + css2FontPath);
@@ -254,8 +254,8 @@ var fetchStream = function(options, session, callback){
                   // SCSS:
                   if (options.styles) {
                     var cssPath = (!options.scss) ?
-                    path.join(options.styles, path.basename(entry.path)) :
-                    path.join(options.styles, '_' + path.basename(entry.path).replace(ext, '.scss'));
+                      path.join(options.styles, path.basename(entry.path)) :
+                      path.join(options.styles, '_' + path.basename(entry.path).replace(ext, '.scss'));
                     return entry.pipe(fs.createWriteStream(cssPath));
                   }
                 // Drain everything else


### PR DESCRIPTION
Added a new option that allows you to explicitly specify to path to the Fontello fonts that is used in the outputted _.css_/_.scss_